### PR TITLE
Add bindspec interpreter, full converter redesign for much more felxibility and reliability

### DIFF
--- a/bindspec/bindspec_test.go
+++ b/bindspec/bindspec_test.go
@@ -35,7 +35,7 @@ func TestBindspec(t *testing.T) {
 				}
 				require.EqualError(err, expect)
 			}
-			for _, x := range bs {
+			for _, x := range bs.Body {
 				fmt.Println(x)
 			}
 			_ = bs

--- a/bindspec/interp.go
+++ b/bindspec/interp.go
@@ -1,0 +1,152 @@
+package bindspec
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/iancoleman/strcase"
+)
+
+// An interface defines how the bindspec interpreter
+// should run commands.
+type Interface struct {
+	// All packages.
+	Pkgs []string
+	// All names by package.
+	Names map[string][]string
+	// Renames the selected symbol.
+	Rename func(pkg, name, newName string)
+	// Includes or excludes the selected symbol.
+	SetIncluded func(pkg, name string, included bool)
+}
+
+// Runs the bindspec program. iface determines
+// how all actions are performed.
+func Run(prog *Program, iface Interface) error {
+	nameIdx := map[string]map[string]int{} // pkg and name to index
+	for pkg, names := range iface.Names {
+		// We'll change symbol names as we go,
+		// so create a copy.
+		iface.Names[pkg] = slices.Clone(names)
+
+		nameIdx[pkg] = map[string]int{}
+		for i, name := range names {
+			nameIdx[pkg][name] = i
+		}
+	}
+
+	// Updates the internal record, then renames. ALWAYS use this.
+	doRename := func(pkg, name, newName string) {
+		idxs, ok := nameIdx[pkg]
+		if !ok {
+			panic("invalid package name")
+		}
+		idx, ok := idxs[name]
+		if !ok {
+			panic("invalid symbol name")
+		}
+		iface.Names[pkg][idx] = newName
+		nameIdx[pkg][newName] = idx
+		iface.Rename(pkg, name, newName)
+	}
+
+	type sym struct {
+		pkgIdx int
+		name   string
+	}
+
+	var selPkgs []string
+	var selPkgBackrefs [][][]byte
+	var selSyms []sym
+	var selSymNameBackrefs [][][]byte
+	for _, cmd := range prog.Body {
+		errorHere := func(format string, args ...any) error {
+			return fmt.Errorf("%v:%v: %w", prog.Filename, cmd.LineNo, fmt.Errorf(format, args...))
+		}
+
+		selPkgs = selPkgs[:0]
+		selPkgBackrefs = selPkgBackrefs[:0]
+		selSyms = selSyms[:0]
+		selSymNameBackrefs = selSymNameBackrefs[:0]
+		var selPkgSeen, selNameSeen bool
+		for _, sel := range cmd.Selectors {
+			switch sel.Type {
+			case SelPkg:
+				if selNameSeen {
+					return errorHere("package selector must come before name selector")
+				}
+				if selPkgSeen {
+					return errorHere("duplicate package selector")
+				}
+				for _, pkg := range iface.Pkgs {
+					m := sel.Regexp.FindSubmatch([]byte(pkg))
+					if m != nil {
+						selPkgs = append(selPkgs, pkg)
+						selPkgBackrefs = append(selPkgBackrefs, m[1:])
+					}
+				}
+			case SelName:
+				if !selPkgSeen {
+					selPkgs = append(selPkgs, iface.Pkgs...)
+					selPkgBackrefs = append(selPkgBackrefs, nil)
+				}
+				if selNameSeen {
+					return errorHere("duplicate name selector")
+				}
+				for pkgIdx, pkg := range selPkgs {
+					for _, name := range iface.Names[pkg] {
+						m := sel.Regexp.FindSubmatch([]byte(name))
+						if m != nil {
+							selSyms = append(selSyms, sym{pkgIdx, name})
+							selSymNameBackrefs = append(selSymNameBackrefs, m[1:])
+						}
+					}
+				}
+			default:
+				return errorHere("unknown selector type %v", sel.Type)
+			}
+		}
+		switch cmd.Action {
+		case Rename:
+			for symIdx, sym := range selSyms {
+				backrefs := append(append([][]byte{},
+					selPkgBackrefs[sym.pkgIdx]...),
+					selSymNameBackrefs[symIdx]...)
+				oldnew := [2 * 9]string{
+					`\1`, "",
+					`\2`, "",
+					`\3`, "",
+					`\4`, "",
+					`\5`, "",
+					`\6`, "",
+					`\7`, "",
+					`\8`, "",
+					`\9`, "",
+				}
+				for i := range min(len(backrefs), 9) {
+					oldnew[2*i+1] = string(backrefs[i])
+				}
+				rep := strings.NewReplacer(oldnew[:]...)
+				newName := rep.Replace(cmd.ActionParam)
+				doRename(selPkgs[sym.pkgIdx], sym.name, newName)
+			}
+		case ToKebab:
+			for _, sym := range selSyms {
+				doRename(selPkgs[sym.pkgIdx], sym.name, strcase.ToKebab(sym.name))
+			}
+		case Include:
+			for _, sym := range selSyms {
+				iface.SetIncluded(selPkgs[sym.pkgIdx], sym.name, true)
+			}
+		case Exclude:
+			for _, sym := range selSyms {
+				iface.SetIncluded(selPkgs[sym.pkgIdx], sym.name, false)
+			}
+		default:
+			return errorHere("unknown action type %v", cmd.Action)
+		}
+	}
+
+	return nil
+}

--- a/bindspec/nodes.go
+++ b/bindspec/nodes.go
@@ -2,24 +2,39 @@ package bindspec
 
 import "regexp"
 
+type SelectorType int
+
+const (
+	SelPkg SelectorType = iota
+	SelName
+)
+
 type Action int
 
 const (
 	Rename Action = iota
 	ToKebab
+	Include
 	Exclude
 )
 
+type Selector struct {
+	Type SelectorType
+	// Invert selector
+	Not bool
+	// Regex
+	Regexp *regexp.Regexp
+}
+
 type Stmt struct {
-	// Invert package selector.
-	NotPkg bool
-	// Package selector, or nil to select all.
-	PkgSelector *regexp.Regexp
-	// Invert name selector.
-	NotName bool
-	// Name selector, or nil to select all.
-	NameSelector *regexp.Regexp
+	LineNo    int
+	Selectors []Selector
 	// What to do with selection.
 	Action      Action
 	ActionParam string
+}
+
+type Program struct {
+	Filename string
+	Body     []*Stmt
 }

--- a/converter/converter_test.go
+++ b/converter/converter_test.go
@@ -47,6 +47,7 @@ func TestConverter(t *testing.T) {
 	testConverter(t, "from_rye/func_02_with_params.go", "func(a, b int, c string, d []int)", FromRye)
 	testConverter(t, "from_rye/func_03_single_result.go", "func() string", FromRye)
 	testConverter(t, "from_rye/func_04_multiple_results.go", "func() (string, int, []string)", FromRye)
+	testConverter(t, "from_rye/any.go", "any", FromRye)
 }
 
 // If filename doesn't exist, the resulting converter will be written to the file
@@ -73,14 +74,15 @@ func doTestConverter(t *testing.T, filename, typeExpr string, dir Direction) {
 	err = types.CheckExpr(token.NewFileSet(), nil, token.NoPos, typExpr, &info)
 	require.NoError(err)
 	cs := NewConverterSet()
-	require.NoError(cs.Add(info.TypeOf(typExpr), dir))
+	_, err = cs.Add(info.TypeOf(typExpr), dir)
+	require.NoError(err)
 	got := cs.genCode(false)
 	if info, err := os.Stat(filePath); err == nil && info.Mode().IsRegular() {
 		expect, err := os.ReadFile(filePath)
 		require.NoError(err)
-		require.Equal(string(expect), got, "Test: \"%v\" %v -> %v", typeExpr, dir, filePath)
+		require.Equal(string(expect), string(got), "Test: \"%v\" %v -> %v", typeExpr, dir, filePath)
 	} else {
-		err := os.WriteFile(filePath, []byte(got), 0666)
+		err := os.WriteFile(filePath, got, 0666)
 		require.NoError(err)
 	}
 }

--- a/converter/converter_test.go
+++ b/converter/converter_test.go
@@ -1,4 +1,4 @@
-package converter_test
+package converter
 
 import (
 	"go/ast"
@@ -7,62 +7,59 @@ import (
 	"go/types"
 	"os"
 	"path"
-	"path/filepath"
-	"strings"
 	"testing"
 
-	"github.com/refaktor/ryegen/v2/converter"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConverter(t *testing.T) {
 	// To Rye
-	testConverter(t, "to_rye/integer_int.go", "int", converter.ToRye)
-	testConverter(t, "to_rye/integer_byte.go", "byte", converter.ToRye)
-	testConverter(t, "to_rye/integer_uint8.go", "uint8", converter.ToRye)
-	testConverter(t, "to_rye/integer_int32.go", "int32", converter.ToRye)
-	testConverter(t, "to_rye/float32.go", "float32", converter.ToRye)
-	testConverter(t, "to_rye/float64.go", "float64", converter.ToRye)
-	testConverter(t, "to_rye/string.go", "string", converter.ToRye)
-	testConverter(t, "to_rye/error.go", "error", converter.ToRye)
-	testConverter(t, "to_rye/map_01_basic.go", "map[string]int", converter.ToRye)
-	testConverter(t, "to_rye/map_02_nonstring.go", "map[int]int", converter.ToRye)
-	testConverter(t, "to_rye/func_01_no_params.go", "func()", converter.ToRye)
-	testConverter(t, "to_rye/func_02_with_params.go", "func(a, b int, c string, d map[int]int)", converter.ToRye)
-	testConverter(t, "to_rye/func_03_single_result.go", "func() string", converter.ToRye)
-	testConverter(t, "to_rye/func_04_error_result.go", "func() (string, error)", converter.ToRye)
-	testConverter(t, "to_rye/func_05_multiple_results.go", "func() (string, int, map[string]string)", converter.ToRye)
-	testConverter(t, "to_rye/slice_01_basic.go", "[]int", converter.ToRye)
-	testConverter(t, "to_rye/array_01_basic.go", "[69]int", converter.ToRye)
+	testConverter(t, "to_rye/integer_int.go", "int", ToRye)
+	testConverter(t, "to_rye/integer_byte.go", "byte", ToRye)
+	testConverter(t, "to_rye/integer_uint8.go", "uint8", ToRye)
+	testConverter(t, "to_rye/integer_int32.go", "int32", ToRye)
+	testConverter(t, "to_rye/float32.go", "float32", ToRye)
+	testConverter(t, "to_rye/float64.go", "float64", ToRye)
+	testConverter(t, "to_rye/string.go", "string", ToRye)
+	testConverter(t, "to_rye/error.go", "error", ToRye)
+	testConverter(t, "to_rye/map_01_basic.go", "map[string]int", ToRye)
+	testConverter(t, "to_rye/map_02_nonstring.go", "map[int]int", ToRye)
+	testConverter(t, "to_rye/func_01_no_params.go", "func()", ToRye)
+	testConverter(t, "to_rye/func_02_with_params.go", "func(a, b int, c string, d []string)", ToRye)
+	testConverter(t, "to_rye/func_03_single_result.go", "func() string", ToRye)
+	testConverter(t, "to_rye/func_04_error_result.go", "func() (string, error)", ToRye)
+	testConverter(t, "to_rye/func_05_multiple_results.go", "func() (string, int, map[string]string)", ToRye)
+	testConverter(t, "to_rye/slice_01_basic.go", "[]int", ToRye)
+	testConverter(t, "to_rye/array_01_basic.go", "[69]int", ToRye)
 
 	// From Rye
-	testConverter(t, "from_rye/integer_int.go", "int", converter.FromRye)
-	testConverter(t, "from_rye/integer_uint16.go", "uint16", converter.FromRye)
-	testConverter(t, "from_rye/integer_uint64.go", "uint64", converter.FromRye)
-	testConverter(t, "from_rye/float32.go", "float32", converter.FromRye)
-	testConverter(t, "from_rye/float64.go", "float64", converter.FromRye)
-	testConverter(t, "from_rye/string.go", "string", converter.FromRye)
-	testConverter(t, "from_rye/error.go", "error", converter.FromRye)
-	testConverter(t, "from_rye/ptr_int.go", "*int", converter.FromRye)
-	testConverter(t, "from_rye/slice_01_basic.go", "[]int", converter.FromRye)
-	testConverter(t, "from_rye/array_01_basic.go", "[69]int", converter.FromRye)
-	testConverter(t, "from_rye/func_01_no_params.go", "func()", converter.FromRye)
-	testConverter(t, "from_rye/func_02_with_params.go", "func(a, b int, c string, d map[int]int)", converter.FromRye)
-	testConverter(t, "from_rye/func_03_single_result.go", "func() string", converter.FromRye)
-	testConverter(t, "from_rye/func_04_multiple_results.go", "func() (string, int, map[string]string)", converter.FromRye)
+	testConverter(t, "from_rye/integer_int.go", "int", FromRye)
+	testConverter(t, "from_rye/integer_uint16.go", "uint16", FromRye)
+	testConverter(t, "from_rye/integer_uint64.go", "uint64", FromRye)
+	testConverter(t, "from_rye/float32.go", "float32", FromRye)
+	testConverter(t, "from_rye/float64.go", "float64", FromRye)
+	testConverter(t, "from_rye/string.go", "string", FromRye)
+	testConverter(t, "from_rye/error.go", "error", FromRye)
+	testConverter(t, "from_rye/ptr_int.go", "*int", FromRye)
+	testConverter(t, "from_rye/slice_01_basic.go", "[]int", FromRye)
+	testConverter(t, "from_rye/array_01_basic.go", "[69]int", FromRye)
+	testConverter(t, "from_rye/func_01_no_params.go", "func()", FromRye)
+	testConverter(t, "from_rye/func_02_with_params.go", "func(a, b int, c string, d []int)", FromRye)
+	testConverter(t, "from_rye/func_03_single_result.go", "func() string", FromRye)
+	testConverter(t, "from_rye/func_04_multiple_results.go", "func() (string, int, []string)", FromRye)
 }
 
 // If filename doesn't exist, the resulting converter will be written to the file
 // without checking against anything. If filename does exist, the resulting
 // converter will be checked against the contents of the file.
-func testConverter(t *testing.T, filename, typeExpr string, dir converter.Direction) {
+func testConverter(t *testing.T, filename, typeExpr string, dir Direction) {
 	t.Helper()
-	t.Run(filepath.Base(strings.TrimSuffix(filename, ".go")+" "+dir.String()), func(t *testing.T) {
+	t.Run(filename, func(t *testing.T) {
 		doTestConverter(t, filename, typeExpr, dir)
 	})
 }
 
-func doTestConverter(t *testing.T, filename, typeExpr string, dir converter.Direction) {
+func doTestConverter(t *testing.T, filename, typeExpr string, dir Direction) {
 	require := require.New(t)
 	filePath := path.Join("testdata", filename)
 	require.NoError(os.MkdirAll(path.Dir(filePath), os.ModePerm))
@@ -75,8 +72,9 @@ func doTestConverter(t *testing.T, filename, typeExpr string, dir converter.Dire
 	}
 	err = types.CheckExpr(token.NewFileSet(), nil, token.NoPos, typExpr, &info)
 	require.NoError(err)
-	got, _, err := converter.NewSpec(info.TypeOf(typExpr), dir).Generate()
-	require.NoError(err)
+	cs := NewConverterSet()
+	require.NoError(cs.Add(info.TypeOf(typExpr), dir))
+	got := cs.genCode(false)
 	if info, err := os.Stat(filePath); err == nil && info.Mode().IsRegular() {
 		expect, err := os.ReadFile(filePath)
 		require.NoError(err)

--- a/converter/from_rye.go.tmpl
+++ b/converter/from_rye.go.tmpl
@@ -61,7 +61,7 @@ func {{ conv . fromRye }}(ps *_env.ProgramState, obj _env.Object) ({{ typStr . }
 
 
 {{ define "error" -}}
-func {{ conv . fromRye }}(ps *_env.ProgramState, obj _env.Object) (error, error) {
+func {{ conv . fromRye }}(ps *_env.ProgramState, obj _env.Object) ({{ typStr . }}, error) {
 	if isNil(obj) {
 		return nil, nil
 	}

--- a/converter/templates.go
+++ b/converter/templates.go
@@ -9,17 +9,14 @@ import (
 	"text/template"
 )
 
-var templateToRye = template.Must(template.New("to_rye.tmpl").Funcs(templateFuncMap).Parse(templateSrcToRye))
-var templateFromRye = template.Must(template.New("from_rye.tmpl").Funcs(templateFuncMap).Parse(templateSrcFromRye))
-
 //go:embed to_rye.go.tmpl
 var templateSrcToRye string
 
 //go:embed from_rye.go.tmpl
 var templateSrcFromRye string
 
-// Common Go code required by generated converters.
-const InitCode = `import (
+// Prelude code required by generated converters.
+const PreludeCode = `import (
 	_errors "errors"
 	_fmt "fmt"
 	_reflect "reflect"
@@ -84,9 +81,12 @@ var templateFuncMap = template.FuncMap{
 	"toRye":   func() Direction { return ToRye },
 	"fromRye": func() Direction { return FromRye },
 	// Returns the converter function name for typ.
-	"conv": func(typ types.Type, dir Direction) string {
-		return NewSpec(typ, dir).Name()
-	},
+	// Invoking this function will mark the converter
+	// as a dependency of the converter it was invoked
+	// from.
+	//
+	// Dynamically generated for dependency tracking.,
+	"conv": (func(typ types.Type, dir Direction) string)(nil),
 	// Returns a canonical string form of a types.Object.
 	"objStr": func(obj types.Object) string {
 		return types.ObjectString(
@@ -95,12 +95,11 @@ var templateFuncMap = template.FuncMap{
 		)
 	},
 	// Returns a canonical string form of a types.Type.
-	"typStr": func(typ types.Type) string {
-		return types.TypeString(
-			typ,
-			PkgImportNameQualifier,
-		)
-	},
+	// Invoking this function will mark the type as an
+	// import dependency of the converter it was invoked from.
+	//
+	// Dynamically generated for dependency tracking.
+	"typStr": (func(typ types.Type) string)(nil),
 	"isStruct": func(typ types.Type) bool {
 		_, ok := typ.(*types.Struct)
 		return ok

--- a/converter/testdata/from_rye/any.go
+++ b/converter/testdata/from_rye/any.go
@@ -1,0 +1,7 @@
+var typeLookup = map[string]map[string]string{}
+func conv_unk_e6f7b419052023cd_fromRye(ps *_env.ProgramState, obj _env.Object) (any, error) {
+	if nat, ok := obj.(_env.Native); ok {
+		return nat.Value, nil
+	}
+	return nil, _errors.New("expected Native, but got " + objectType(ps, obj))
+}

--- a/converter/testdata/from_rye/array_01_basic.go
+++ b/converter/testdata/from_rye/array_01_basic.go
@@ -20,3 +20,15 @@ func conv_array_69_int_fromRye(ps *_env.ProgramState, obj _env.Object) ([69]int,
 	}
 	return [69]int{}, _errors.New("expected block of type int, but got " + objectType(ps, obj))
 }
+
+func conv_int_fromRye(ps *_env.ProgramState, obj _env.Object) (int, error) {
+	if x, ok := obj.(_env.Integer); ok {
+		return int(x.Value), nil
+	}
+	if nat, ok := obj.(_env.Native); ok {
+		if v, ok := nat.Value.(int); ok {
+			return v, nil
+		}
+	}
+	return 0, _errors.New("expected int, but got " + objectType(ps, obj))
+}

--- a/converter/testdata/from_rye/array_01_basic.go
+++ b/converter/testdata/from_rye/array_01_basic.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_array_69_int_fromRye(ps *_env.ProgramState, obj _env.Object) ([69]int, error) {
 	if blk, ok := obj.(_env.Block); ok {
 		if len(blk.Series.S) != 69 {

--- a/converter/testdata/from_rye/error.go
+++ b/converter/testdata/from_rye/error.go
@@ -1,3 +1,9 @@
+var typeLookup = map[string]map[string]string{}
+func init() {
+	typeLookup[""] = map[string]string{}
+	typeLookup[""]["error"] = ".error"
+}
+
 func conv_error_fromRye(ps *_env.ProgramState, obj _env.Object) (error, error) {
 	if isNil(obj) {
 		return nil, nil

--- a/converter/testdata/from_rye/float32.go
+++ b/converter/testdata/from_rye/float32.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_float32_fromRye(ps *_env.ProgramState, obj _env.Object) (float32, error) {
 	if x, ok := obj.(_env.Decimal); ok {
 		return float32(x.Value), nil

--- a/converter/testdata/from_rye/float64.go
+++ b/converter/testdata/from_rye/float64.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_float64_fromRye(ps *_env.ProgramState, obj _env.Object) (float64, error) {
 	if x, ok := obj.(_env.Decimal); ok {
 		return float64(x.Value), nil

--- a/converter/testdata/from_rye/func_01_no_params.go
+++ b/converter/testdata/from_rye/func_01_no_params.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_func_1926bfa0a15a6c3c_fromRye(ps *_env.ProgramState, obj _env.Object) (func(), error) {
 	if fn, ok := obj.(_env.Function); ok {
 		if fn.Argsn != 0 {

--- a/converter/testdata/from_rye/func_01_no_params.go
+++ b/converter/testdata/from_rye/func_01_no_params.go
@@ -6,7 +6,7 @@ func conv_func_1926bfa0a15a6c3c_fromRye(ps *_env.ProgramState, obj _env.Object) 
 		return func() {
 			_evaldo.CallFunctionArgsN(fn, ps, ps.Ctx)
 			if e, ok := ps.Res.(*_env.Error); ok {
-				showFunctionError(*ps.Idx, fn, _errors.New(e.Message))
+				showFunctionError(ps, fn, _errors.New(e.Message))
 				return
 			}
 		}, nil

--- a/converter/testdata/from_rye/func_02_with_params.go
+++ b/converter/testdata/from_rye/func_02_with_params.go
@@ -1,40 +1,60 @@
-func conv_func_16892ac2e1c990f5_fromRye(ps *_env.ProgramState, obj _env.Object) (func(a int, b int, c string, d map[int]int), error) {
+func conv_slice_int_toRye(ps *_env.ProgramState, a []int) (_env.Block, error) {
+	items := make([]_env.Object, len(a))
+	for i := range a {
+		var err error
+		items[i], err = conv_int_toRye(ps, a[i])
+		if err != nil {
+			return _env.Block{}, err
+		}
+	}
+	return *_env.NewBlock(*_env.NewTSeries(items)), nil
+}
+
+func conv_int_toRye(ps *_env.ProgramState, x int) (_env.Integer, error) {
+	return *_env.NewInteger(int64(x)), nil
+}
+
+func conv_string_toRye(ps *_env.ProgramState, x string) (_env.String, error) {
+	return *_env.NewString(x), nil
+}
+
+func conv_func_12c572ea71e5b4ba_fromRye(ps *_env.ProgramState, obj _env.Object) (func(a int, b int, c string, d []int), error) {
 	if fn, ok := obj.(_env.Function); ok {
 		if fn.Argsn != 4 {
 			return nil, _errors.New("expected function with 4 args, but got " + objectType(ps, obj))
 		}
-		return func(inArg0 int, inArg1 int, inArg2 string, inArg3 map[int]int) {
+		return func(inArg0 int, inArg1 int, inArg2 string, inArg3 []int) {
 			arg0, err := conv_int_toRye(ps, inArg0)
 			if err != nil {
-				showFunctionError(*ps.Idx, fn, err)
+				showFunctionError(ps, fn, err)
 				return
 			}
 			arg1, err := conv_int_toRye(ps, inArg1)
 			if err != nil {
-				showFunctionError(*ps.Idx, fn, err)
+				showFunctionError(ps, fn, err)
 				return
 			}
 			arg2, err := conv_string_toRye(ps, inArg2)
 			if err != nil {
-				showFunctionError(*ps.Idx, fn, err)
+				showFunctionError(ps, fn, err)
 				return
 			}
-			arg3, err := conv_map_int_int_toRye(ps, inArg3)
+			arg3, err := conv_slice_int_toRye(ps, inArg3)
 			if err != nil {
-				showFunctionError(*ps.Idx, fn, err)
+				showFunctionError(ps, fn, err)
 				return
 			}
 			_evaldo.CallFunctionArgsN(fn, ps, ps.Ctx, arg0, arg1, arg2, arg3)
 			if e, ok := ps.Res.(*_env.Error); ok {
-				showFunctionError(*ps.Idx, fn, _errors.New(e.Message))
+				showFunctionError(ps, fn, _errors.New(e.Message))
 				return
 			}
 		}, nil
 	}
 	if nat, ok := obj.(_env.Native); ok {
-		if v, ok := nat.Value.(func(a int, b int, c string, d map[int]int)); ok {
+		if v, ok := nat.Value.(func(a int, b int, c string, d []int)); ok {
 			return v, nil
 		}
 	}
-	return nil, _errors.New("expected function or native of type go(func(a int, b int, c string, d map[int]int)), but got " + objectType(ps, obj))
+	return nil, _errors.New("expected function or native of type go(func(a int, b int, c string, d []int)), but got " + objectType(ps, obj))
 }

--- a/converter/testdata/from_rye/func_02_with_params.go
+++ b/converter/testdata/from_rye/func_02_with_params.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_slice_int_toRye(ps *_env.ProgramState, a []int) (_env.Block, error) {
 	items := make([]_env.Object, len(a))
 	for i := range a {

--- a/converter/testdata/from_rye/func_03_single_result.go
+++ b/converter/testdata/from_rye/func_03_single_result.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_func_c4f955a1345caff5_fromRye(ps *_env.ProgramState, obj _env.Object) (func() string, error) {
 	if fn, ok := obj.(_env.Function); ok {
 		if fn.Argsn != 0 {

--- a/converter/testdata/from_rye/func_03_single_result.go
+++ b/converter/testdata/from_rye/func_03_single_result.go
@@ -6,12 +6,12 @@ func conv_func_c4f955a1345caff5_fromRye(ps *_env.ProgramState, obj _env.Object) 
 		return func() (_ string) {
 			_evaldo.CallFunctionArgsN(fn, ps, ps.Ctx)
 			if e, ok := ps.Res.(*_env.Error); ok {
-				showFunctionError(*ps.Idx, fn, _errors.New(e.Message))
+				showFunctionError(ps, fn, _errors.New(e.Message))
 				return
 			}
 			res, err := conv_string_fromRye(ps, ps.Res)
 			if err != nil {
-				showFunctionError(*ps.Idx, fn, err)
+				showFunctionError(ps, fn, err)
 				return
 			}
 			return res
@@ -23,4 +23,16 @@ func conv_func_c4f955a1345caff5_fromRye(ps *_env.ProgramState, obj _env.Object) 
 		}
 	}
 	return nil, _errors.New("expected function or native of type go(func() string), but got " + objectType(ps, obj))
+}
+
+func conv_string_fromRye(ps *_env.ProgramState, obj _env.Object) (string, error) {
+	if x, ok := obj.(_env.String); ok {
+		return x.Value, nil
+	}
+	if nat, ok := obj.(_env.Native); ok {
+		if v, ok := nat.Value.(string); ok {
+			return v, nil
+		}
+	}
+	return "", _errors.New("expected string, but got " + objectType(ps, obj))
 }

--- a/converter/testdata/from_rye/func_04_multiple_results.go
+++ b/converter/testdata/from_rye/func_04_multiple_results.go
@@ -1,45 +1,89 @@
-func conv_func_ac731ded5a42d0a5_fromRye(ps *_env.ProgramState, obj _env.Object) (func() (string, int, map[string]string), error) {
+func conv_slice_string_fromRye(ps *_env.ProgramState, obj _env.Object) ([]string, error) {
+	if blk, ok := obj.(_env.Block); ok {
+		items := make([]string, len(blk.Series.S))
+		for i, v := range blk.Series.S {
+			var err error
+			items[i], err = conv_string_fromRye(ps, v)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return items, nil
+	}
+	if nat, ok := obj.(_env.Native); ok {
+		if v, ok := nat.Value.([]string); ok {
+			return v, nil
+		}
+	}
+	return nil, _errors.New("expected block of type string, but got " + objectType(ps, obj))
+}
+
+func conv_func_c2fb56a42cb0385a_fromRye(ps *_env.ProgramState, obj _env.Object) (func() (string, int, []string), error) {
 	if fn, ok := obj.(_env.Function); ok {
 		if fn.Argsn != 0 {
 			return nil, _errors.New("expected function with 0 args, but got " + objectType(ps, obj))
 		}
-		return func() (_ string, _ int, _ map[string]string) {
+		return func() (_ string, _ int, _ []string) {
 			_evaldo.CallFunctionArgsN(fn, ps, ps.Ctx)
 			if e, ok := ps.Res.(*_env.Error); ok {
-				showFunctionError(*ps.Idx, fn, _errors.New(e.Message))
+				showFunctionError(ps, fn, _errors.New(e.Message))
 				return
 			}
 			blk, ok := ps.Res.(_env.Block)
 			if !ok {
-				showFunctionError(*ps.Idx, fn, _errors.New("expected block with results, but got " +  objectType(ps, ps.Res)))
+				showFunctionError(ps, fn, _errors.New("expected block with results, but got " +  objectType(ps, ps.Res)))
 				return
 			}
 			if len(blk.Series.S) != 3 {
-				showFunctionError(*ps.Idx, fn, _fmt.Errorf("expected 3 results, but got %v", len(blk.Series.S)))
+				showFunctionError(ps, fn, _fmt.Errorf("expected 3 results, but got %v", len(blk.Series.S)))
 				return
 			}
 			res0, err := conv_string_fromRye(ps, blk.Series.S[0])
 			if err != nil {
-				showFunctionError(*ps.Idx, fn, err)
+				showFunctionError(ps, fn, err)
 				return
 			}
 			res1, err := conv_int_fromRye(ps, blk.Series.S[1])
 			if err != nil {
-				showFunctionError(*ps.Idx, fn, err)
+				showFunctionError(ps, fn, err)
 				return
 			}
-			res2, err := conv_map_string_string_fromRye(ps, blk.Series.S[2])
+			res2, err := conv_slice_string_fromRye(ps, blk.Series.S[2])
 			if err != nil {
-				showFunctionError(*ps.Idx, fn, err)
+				showFunctionError(ps, fn, err)
 				return
 			}
 			return res0, res1, res2
 		}, nil
 	}
 	if nat, ok := obj.(_env.Native); ok {
-		if v, ok := nat.Value.(func() (string, int, map[string]string)); ok {
+		if v, ok := nat.Value.(func() (string, int, []string)); ok {
 			return v, nil
 		}
 	}
-	return nil, _errors.New("expected function or native of type go(func() (string, int, map[string]string)), but got " + objectType(ps, obj))
+	return nil, _errors.New("expected function or native of type go(func() (string, int, []string)), but got " + objectType(ps, obj))
+}
+
+func conv_int_fromRye(ps *_env.ProgramState, obj _env.Object) (int, error) {
+	if x, ok := obj.(_env.Integer); ok {
+		return int(x.Value), nil
+	}
+	if nat, ok := obj.(_env.Native); ok {
+		if v, ok := nat.Value.(int); ok {
+			return v, nil
+		}
+	}
+	return 0, _errors.New("expected int, but got " + objectType(ps, obj))
+}
+
+func conv_string_fromRye(ps *_env.ProgramState, obj _env.Object) (string, error) {
+	if x, ok := obj.(_env.String); ok {
+		return x.Value, nil
+	}
+	if nat, ok := obj.(_env.Native); ok {
+		if v, ok := nat.Value.(string); ok {
+			return v, nil
+		}
+	}
+	return "", _errors.New("expected string, but got " + objectType(ps, obj))
 }

--- a/converter/testdata/from_rye/func_04_multiple_results.go
+++ b/converter/testdata/from_rye/func_04_multiple_results.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_slice_string_fromRye(ps *_env.ProgramState, obj _env.Object) ([]string, error) {
 	if blk, ok := obj.(_env.Block); ok {
 		items := make([]string, len(blk.Series.S))

--- a/converter/testdata/from_rye/integer_int.go
+++ b/converter/testdata/from_rye/integer_int.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_int_fromRye(ps *_env.ProgramState, obj _env.Object) (int, error) {
 	if x, ok := obj.(_env.Integer); ok {
 		return int(x.Value), nil

--- a/converter/testdata/from_rye/integer_uint16.go
+++ b/converter/testdata/from_rye/integer_uint16.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_uint16_fromRye(ps *_env.ProgramState, obj _env.Object) (uint16, error) {
 	if x, ok := obj.(_env.Integer); ok {
 		return uint16(x.Value), nil

--- a/converter/testdata/from_rye/integer_uint64.go
+++ b/converter/testdata/from_rye/integer_uint64.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_uint64_fromRye(ps *_env.ProgramState, obj _env.Object) (uint64, error) {
 	if x, ok := obj.(_env.Integer); ok {
 		return uint64(x.Value), nil

--- a/converter/testdata/from_rye/ptr_int.go
+++ b/converter/testdata/from_rye/ptr_int.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_ptr_int_fromRye(ps *_env.ProgramState, obj _env.Object) (*int, error) {
 	if isNil(obj) {
 		return nil, nil

--- a/converter/testdata/from_rye/ptr_int.go
+++ b/converter/testdata/from_rye/ptr_int.go
@@ -12,3 +12,15 @@ func conv_ptr_int_fromRye(ps *_env.ProgramState, obj _env.Object) (*int, error) 
 	}
 	return nil, _errors.New("expected Native of type *int, or any element type, but got " + objectType(ps, obj))
 }
+
+func conv_int_fromRye(ps *_env.ProgramState, obj _env.Object) (int, error) {
+	if x, ok := obj.(_env.Integer); ok {
+		return int(x.Value), nil
+	}
+	if nat, ok := obj.(_env.Native); ok {
+		if v, ok := nat.Value.(int); ok {
+			return v, nil
+		}
+	}
+	return 0, _errors.New("expected int, but got " + objectType(ps, obj))
+}

--- a/converter/testdata/from_rye/slice_01_basic.go
+++ b/converter/testdata/from_rye/slice_01_basic.go
@@ -17,3 +17,15 @@ func conv_slice_int_fromRye(ps *_env.ProgramState, obj _env.Object) ([]int, erro
 	}
 	return nil, _errors.New("expected block of type int, but got " + objectType(ps, obj))
 }
+
+func conv_int_fromRye(ps *_env.ProgramState, obj _env.Object) (int, error) {
+	if x, ok := obj.(_env.Integer); ok {
+		return int(x.Value), nil
+	}
+	if nat, ok := obj.(_env.Native); ok {
+		if v, ok := nat.Value.(int); ok {
+			return v, nil
+		}
+	}
+	return 0, _errors.New("expected int, but got " + objectType(ps, obj))
+}

--- a/converter/testdata/from_rye/slice_01_basic.go
+++ b/converter/testdata/from_rye/slice_01_basic.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_slice_int_fromRye(ps *_env.ProgramState, obj _env.Object) ([]int, error) {
 	if blk, ok := obj.(_env.Block); ok {
 		items := make([]int, len(blk.Series.S))

--- a/converter/testdata/from_rye/string.go
+++ b/converter/testdata/from_rye/string.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_string_fromRye(ps *_env.ProgramState, obj _env.Object) (string, error) {
 	if x, ok := obj.(_env.String); ok {
 		return x.Value, nil

--- a/converter/testdata/to_rye/array_01_basic.go
+++ b/converter/testdata/to_rye/array_01_basic.go
@@ -9,3 +9,7 @@ func conv_array_69_int_toRye(ps *_env.ProgramState, a [69]int) (_env.Block, erro
 	}
 	return *_env.NewBlock(*_env.NewTSeries(items[:])), nil
 }
+
+func conv_int_toRye(ps *_env.ProgramState, x int) (_env.Integer, error) {
+	return *_env.NewInteger(int64(x)), nil
+}

--- a/converter/testdata/to_rye/array_01_basic.go
+++ b/converter/testdata/to_rye/array_01_basic.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_array_69_int_toRye(ps *_env.ProgramState, a [69]int) (_env.Block, error) {
 	var items [69]_env.Object
 	for i := range a {

--- a/converter/testdata/to_rye/error.go
+++ b/converter/testdata/to_rye/error.go
@@ -1,3 +1,9 @@
+var typeLookup = map[string]map[string]string{}
+func init() {
+	typeLookup[""] = map[string]string{}
+	typeLookup[""]["error"] = ".error"
+}
+
 func conv_error_toRye(ps *_env.ProgramState, x error) (*_env.Error, error) {
 	return _env.NewError(x.Error()), nil
 }

--- a/converter/testdata/to_rye/float32.go
+++ b/converter/testdata/to_rye/float32.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_float32_toRye(ps *_env.ProgramState, x float32) (_env.Decimal, error) {
 	return *_env.NewDecimal(float64(x)), nil
 }

--- a/converter/testdata/to_rye/float64.go
+++ b/converter/testdata/to_rye/float64.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_float64_toRye(ps *_env.ProgramState, x float64) (_env.Decimal, error) {
 	return *_env.NewDecimal(float64(x)), nil
 }

--- a/converter/testdata/to_rye/func_01_no_params.go
+++ b/converter/testdata/to_rye/func_01_no_params.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_func_1926bfa0a15a6c3c_toRye(ps *_env.ProgramState, fn func()) (_env.VarBuiltin, error) {
 	outfnErrable := func(ps *_env.ProgramState, args ..._env.Object) (_env.Object, error) {
 		fn()

--- a/converter/testdata/to_rye/func_02_with_params.go
+++ b/converter/testdata/to_rye/func_02_with_params.go
@@ -1,4 +1,4 @@
-func conv_func_16892ac2e1c990f5_toRye(ps *_env.ProgramState, fn func(a int, b int, c string, d map[int]int)) (_env.VarBuiltin, error) {
+func conv_func_233d01fb786b160a_toRye(ps *_env.ProgramState, fn func(a int, b int, c string, d []string)) (_env.VarBuiltin, error) {
 	outfnErrable := func(ps *_env.ProgramState, args ..._env.Object) (_env.Object, error) {
 		arg0, err := conv_int_fromRye(ps, args[0])
 		if err != nil {
@@ -12,7 +12,7 @@ func conv_func_16892ac2e1c990f5_toRye(ps *_env.ProgramState, fn func(a int, b in
 		if err != nil {
 			return *_env.NewVoid(), err
 		}
-		arg3, err := conv_map_int_int_fromRye(ps, args[3])
+		arg3, err := conv_slice_string_fromRye(ps, args[3])
 		if err != nil {
 			return *_env.NewVoid(), err
 		}
@@ -31,4 +31,48 @@ func conv_func_16892ac2e1c990f5_toRye(ps *_env.ProgramState, fn func(a int, b in
 			return res
 		},
 	}, nil
+}
+
+func conv_slice_string_fromRye(ps *_env.ProgramState, obj _env.Object) ([]string, error) {
+	if blk, ok := obj.(_env.Block); ok {
+		items := make([]string, len(blk.Series.S))
+		for i, v := range blk.Series.S {
+			var err error
+			items[i], err = conv_string_fromRye(ps, v)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return items, nil
+	}
+	if nat, ok := obj.(_env.Native); ok {
+		if v, ok := nat.Value.([]string); ok {
+			return v, nil
+		}
+	}
+	return nil, _errors.New("expected block of type string, but got " + objectType(ps, obj))
+}
+
+func conv_int_fromRye(ps *_env.ProgramState, obj _env.Object) (int, error) {
+	if x, ok := obj.(_env.Integer); ok {
+		return int(x.Value), nil
+	}
+	if nat, ok := obj.(_env.Native); ok {
+		if v, ok := nat.Value.(int); ok {
+			return v, nil
+		}
+	}
+	return 0, _errors.New("expected int, but got " + objectType(ps, obj))
+}
+
+func conv_string_fromRye(ps *_env.ProgramState, obj _env.Object) (string, error) {
+	if x, ok := obj.(_env.String); ok {
+		return x.Value, nil
+	}
+	if nat, ok := obj.(_env.Native); ok {
+		if v, ok := nat.Value.(string); ok {
+			return v, nil
+		}
+	}
+	return "", _errors.New("expected string, but got " + objectType(ps, obj))
 }

--- a/converter/testdata/to_rye/func_02_with_params.go
+++ b/converter/testdata/to_rye/func_02_with_params.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_func_233d01fb786b160a_toRye(ps *_env.ProgramState, fn func(a int, b int, c string, d []string)) (_env.VarBuiltin, error) {
 	outfnErrable := func(ps *_env.ProgramState, args ..._env.Object) (_env.Object, error) {
 		arg0, err := conv_int_fromRye(ps, args[0])

--- a/converter/testdata/to_rye/func_03_single_result.go
+++ b/converter/testdata/to_rye/func_03_single_result.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_func_c4f955a1345caff5_toRye(ps *_env.ProgramState, fn func() string) (_env.VarBuiltin, error) {
 	outfnErrable := func(ps *_env.ProgramState, args ..._env.Object) (_env.Object, error) {
 		res0 := fn()

--- a/converter/testdata/to_rye/func_03_single_result.go
+++ b/converter/testdata/to_rye/func_03_single_result.go
@@ -20,3 +20,7 @@ func conv_func_c4f955a1345caff5_toRye(ps *_env.ProgramState, fn func() string) (
 		},
 	}, nil
 }
+
+func conv_string_toRye(ps *_env.ProgramState, x string) (_env.String, error) {
+	return *_env.NewString(x), nil
+}

--- a/converter/testdata/to_rye/func_04_error_result.go
+++ b/converter/testdata/to_rye/func_04_error_result.go
@@ -1,3 +1,9 @@
+var typeLookup = map[string]map[string]string{}
+func init() {
+	typeLookup[""] = map[string]string{}
+	typeLookup[""]["error"] = ".error"
+}
+
 func conv_func_e2cfa6537a62ff24_toRye(ps *_env.ProgramState, fn func() (string, error)) (_env.VarBuiltin, error) {
 	outfnErrable := func(ps *_env.ProgramState, args ..._env.Object) (_env.Object, error) {
 		res0, res1 := fn()

--- a/converter/testdata/to_rye/func_04_error_result.go
+++ b/converter/testdata/to_rye/func_04_error_result.go
@@ -23,3 +23,7 @@ func conv_func_e2cfa6537a62ff24_toRye(ps *_env.ProgramState, fn func() (string, 
 		},
 	}, nil
 }
+
+func conv_string_toRye(ps *_env.ProgramState, x string) (_env.String, error) {
+	return *_env.NewString(x), nil
+}

--- a/converter/testdata/to_rye/func_05_multiple_results.go
+++ b/converter/testdata/to_rye/func_05_multiple_results.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_func_ac731ded5a42d0a5_toRye(ps *_env.ProgramState, fn func() (string, int, map[string]string)) (_env.VarBuiltin, error) {
 	outfnErrable := func(ps *_env.ProgramState, args ..._env.Object) (_env.Object, error) {
 		res0, res1, res2 := fn()

--- a/converter/testdata/to_rye/func_05_multiple_results.go
+++ b/converter/testdata/to_rye/func_05_multiple_results.go
@@ -28,3 +28,23 @@ func conv_func_ac731ded5a42d0a5_toRye(ps *_env.ProgramState, fn func() (string, 
 		},
 	}, nil
 }
+
+func conv_int_toRye(ps *_env.ProgramState, x int) (_env.Integer, error) {
+	return *_env.NewInteger(int64(x)), nil
+}
+
+func conv_map_string_string_toRye(ps *_env.ProgramState, m map[string]string) (_env.Dict, error) {
+	data := make(map[string]any, len(m))
+	for k, v := range m {
+		v1, err := conv_string_toRye(ps, v)
+		if err != nil {
+			return _env.Dict{}, err
+		}
+		data[k] = v1
+	}
+	return *_env.NewDict(data), nil
+}
+
+func conv_string_toRye(ps *_env.ProgramState, x string) (_env.String, error) {
+	return *_env.NewString(x), nil
+}

--- a/converter/testdata/to_rye/integer_byte.go
+++ b/converter/testdata/to_rye/integer_byte.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_byte_toRye(ps *_env.ProgramState, x byte) (_env.Integer, error) {
 	return *_env.NewInteger(int64(x)), nil
 }

--- a/converter/testdata/to_rye/integer_int.go
+++ b/converter/testdata/to_rye/integer_int.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_int_toRye(ps *_env.ProgramState, x int) (_env.Integer, error) {
 	return *_env.NewInteger(int64(x)), nil
 }

--- a/converter/testdata/to_rye/integer_int32.go
+++ b/converter/testdata/to_rye/integer_int32.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_int32_toRye(ps *_env.ProgramState, x int32) (_env.Integer, error) {
 	return *_env.NewInteger(int64(x)), nil
 }

--- a/converter/testdata/to_rye/integer_uint8.go
+++ b/converter/testdata/to_rye/integer_uint8.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_uint8_toRye(ps *_env.ProgramState, x uint8) (_env.Integer, error) {
 	return *_env.NewInteger(int64(x)), nil
 }

--- a/converter/testdata/to_rye/map_01_basic.go
+++ b/converter/testdata/to_rye/map_01_basic.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_int_toRye(ps *_env.ProgramState, x int) (_env.Integer, error) {
 	return *_env.NewInteger(int64(x)), nil
 }

--- a/converter/testdata/to_rye/map_01_basic.go
+++ b/converter/testdata/to_rye/map_01_basic.go
@@ -1,3 +1,7 @@
+func conv_int_toRye(ps *_env.ProgramState, x int) (_env.Integer, error) {
+	return *_env.NewInteger(int64(x)), nil
+}
+
 func conv_map_string_int_toRye(ps *_env.ProgramState, m map[string]int) (_env.Dict, error) {
 	data := make(map[string]any, len(m))
 	for k, v := range m {

--- a/converter/testdata/to_rye/map_02_nonstring.go
+++ b/converter/testdata/to_rye/map_02_nonstring.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_map_int_int_toRye(ps *_env.ProgramState, s map[int]int) (_env.Native, error) {
 	return *_env.NewNative(ps.Idx, &s, "go(*map[int]int)"), nil
 }

--- a/converter/testdata/to_rye/map_02_nonstring.go
+++ b/converter/testdata/to_rye/map_02_nonstring.go
@@ -1,3 +1,3 @@
-func conv_map_int_int_toRye(ps *_env.ProgramState, m map[int]int) (_env.Dict, error) {
-	return *_env.NewNative(ps.Idx, m, "go(map[int]int)"), nil
+func conv_map_int_int_toRye(ps *_env.ProgramState, s map[int]int) (_env.Native, error) {
+	return *_env.NewNative(ps.Idx, &s, "go(*map[int]int)"), nil
 }

--- a/converter/testdata/to_rye/slice_01_basic.go
+++ b/converter/testdata/to_rye/slice_01_basic.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_slice_int_toRye(ps *_env.ProgramState, a []int) (_env.Block, error) {
 	items := make([]_env.Object, len(a))
 	for i := range a {

--- a/converter/testdata/to_rye/slice_01_basic.go
+++ b/converter/testdata/to_rye/slice_01_basic.go
@@ -9,3 +9,7 @@ func conv_slice_int_toRye(ps *_env.ProgramState, a []int) (_env.Block, error) {
 	}
 	return *_env.NewBlock(*_env.NewTSeries(items)), nil
 }
+
+func conv_int_toRye(ps *_env.ProgramState, x int) (_env.Integer, error) {
+	return *_env.NewInteger(int64(x)), nil
+}

--- a/converter/testdata/to_rye/string.go
+++ b/converter/testdata/to_rye/string.go
@@ -1,3 +1,4 @@
+var typeLookup = map[string]map[string]string{}
 func conv_string_toRye(ps *_env.ProgramState, x string) (_env.String, error) {
 	return *_env.NewString(x), nil
 }

--- a/converter/to_rye.go.tmpl
+++ b/converter/to_rye.go.tmpl
@@ -13,14 +13,14 @@ func {{ conv . toRye }}(ps *_env.ProgramState, x {{ typStr . }}) (_env.Decimal, 
 
 
 {{ define "bool" -}}
-func {{ conv . toRye }}(ps *_env.ProgramState, x bool) (_env.Boolean, error) {
+func {{ conv . toRye }}(ps *_env.ProgramState, x {{ typStr . }}) (_env.Boolean, error) {
 	return *_env.NewBoolean(x), nil
 }
 {{- end }}
 
 
 {{ define "string" -}}
-func {{ conv . toRye }}(ps *_env.ProgramState, x string) (_env.String, error) {
+func {{ conv . toRye }}(ps *_env.ProgramState, x {{ typStr . }}) (_env.String, error) {
 	return *_env.NewString(x), nil
 }
 {{- end }}
@@ -34,14 +34,14 @@ func {{ conv . toRye }}(ps *_env.ProgramState, s {{ typStr . }}) (_env.Native, e
 
 
 {{ define "error" -}}
-func {{ conv . toRye }}(ps *_env.ProgramState, x error) (*_env.Error, error) {
+func {{ conv . toRye }}(ps *_env.ProgramState, x {{ typStr . }}) (*_env.Error, error) {
 	return _env.NewError(x.Error()), nil
 }
 {{- end }}
 
 
 {{ define "time" -}}
-func {{ conv . toRye }}(ps *_env.ProgramState, x time.Time) (_env.Time, error) {
+func {{ conv . toRye }}(ps *_env.ProgramState, x {{ typStr . }}) (_env.Time, error) {
 	return *_env.NewTime(x), nil
 }
 {{- end }}

--- a/converter/walktypes/walktypes.go
+++ b/converter/walktypes/walktypes.go
@@ -1,0 +1,325 @@
+/*
+Package walktypes simplifies recursively iterating over types from the Go [types] package.
+*/
+package walktypes
+
+import (
+	"fmt"
+	"go/types"
+	"slices"
+)
+
+// Walk calls fn on all immediate children of type t.
+// Returns early if fn returns an error.
+func Walk(t types.Type, fn func(types.Type) error) error {
+	walk := func(types.Type) error {
+		return fn(t)
+	}
+	walkVar := func(v *types.Var) error {
+		return walk(v.Type())
+	}
+	walkTuple := func(t *types.Tuple) error {
+		for v := range t.Variables() {
+			if err := walkVar(v); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	walkSignature := func(t *types.Signature) error {
+		if t.Recv() != nil {
+			if err := walkVar(t.Recv()); err != nil {
+				return err
+			}
+		}
+		if err := walkTuple(t.Params()); err != nil {
+			return err
+		}
+		if err := walkTuple(t.Results()); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	switch t := t.(type) {
+	case *types.Basic:
+		return nil
+	case *types.Alias:
+		return walk(t.Rhs())
+	case *types.Array:
+		return walk(t.Elem())
+	case *types.Slice:
+		return walk(t.Elem())
+	case *types.Struct:
+		for f := range t.Fields() {
+			if err := walkVar(f); err != nil {
+				return err
+			}
+		}
+		return nil
+	case *types.Pointer:
+		return walk(t.Elem())
+	case *types.Tuple:
+		return walkTuple(t)
+	case *types.Signature:
+		return walkSignature(t)
+	case *types.Union:
+		for term := range t.Terms() {
+			if err := walk(term.Type()); err != nil {
+				return err
+			}
+		}
+		return nil
+	case *types.Interface:
+		for m := range t.ExplicitMethods() {
+			if err := walkSignature(m.Signature()); err != nil {
+				return err
+			}
+		}
+		for e := range t.EmbeddedTypes() {
+			if err := walk(e); err != nil {
+				return err
+			}
+		}
+		return nil
+	case *types.Map:
+		if err := walk(t.Key()); err != nil {
+			return err
+		}
+		if err := walk(t.Elem()); err != nil {
+			return err
+		}
+		return nil
+	case *types.Chan:
+		return walk(t.Elem())
+	case *types.Named:
+		return nil
+	case *types.TypeParam:
+		return nil
+	case nil:
+		return nil
+	default:
+		panic(fmt.Sprintf("Walk: unknown type %T", t))
+	}
+}
+
+// WalkModify calls fn on all immediate children of type t,
+// reconstructing each child with the new returned type.
+// Only reconstructs if a call to fn actually returned
+// a modified type. May still allocate some memory, though.
+// Returns the modified type.
+// Returns early if fn returns an error.
+func WalkModify(t types.Type, fn func(types.Type) (types.Type, error)) (types.Type, error) {
+	walk := func(t types.Type) (_ types.Type, changed bool, err error) {
+		t1, err := fn(t)
+		if err != nil {
+			return nil, false, err
+		}
+		return t1, t1 != t, nil
+	}
+	walkVar := func(v *types.Var) (_ *types.Var, changed bool, err error) {
+		t1, changed, err := walk(v.Type())
+		if err != nil {
+			return nil, false, err
+		}
+		if !changed {
+			return v, false, nil
+		}
+		return types.NewVar(v.Pos(), v.Pkg(), v.Name(), t1), true, nil
+	}
+	walkTuple := func(t *types.Tuple) (_ *types.Tuple, changed bool, err error) {
+		changed = false
+		vars := make([]*types.Var, t.Len())
+		for i := range t.Len() {
+			v1, chngd, err := walkVar(t.At(i))
+			if err != nil {
+				return nil, false, err
+			}
+			if chngd {
+				changed = true
+			}
+			vars[i] = v1
+		}
+		if !changed {
+			return t, false, nil
+		}
+		return types.NewTuple(vars...), true, nil
+	}
+	walkSignature := func(t *types.Signature) (_ *types.Signature, changed bool, err error) {
+		var recv1 *types.Var
+		var recvChanged bool
+		if t.Recv() != nil {
+			var err error
+			recv1, recvChanged, err = walkVar(t.Recv())
+			if err != nil {
+				return nil, false, err
+			}
+		}
+		params1, paramsChanged, err := walkTuple(t.Params())
+		if err != nil {
+			return nil, false, err
+		}
+		results1, resultsChanged, err := walkTuple(t.Results())
+		if err != nil {
+			return nil, false, err
+		}
+		if !recvChanged && !paramsChanged && !resultsChanged {
+			return t, false, err
+		}
+		return types.NewSignatureType(
+			recv1,
+			slices.Collect(t.RecvTypeParams().TypeParams()),
+			slices.Collect(t.TypeParams().TypeParams()),
+			params1,
+			results1,
+			t.Variadic(),
+		), true, nil
+	}
+
+	switch t := t.(type) {
+	case *types.Basic:
+		return t, nil
+	case *types.Alias:
+		t1, changed, err := walk(t.Rhs())
+		if err != nil {
+			return nil, err
+		}
+		if !changed {
+			return t, nil
+		}
+		return types.NewAlias(t.Obj(), t1), nil
+	case *types.Array:
+		t1, changed, err := walk(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+		if !changed {
+			return t, nil
+		}
+		return types.NewArray(t1, t.Len()), nil
+	case *types.Slice:
+		t1, changed, err := walk(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+		if !changed {
+			return t, nil
+		}
+		return types.NewSlice(t1), nil
+	case *types.Struct:
+		changed := false
+		fields := make([]*types.Var, t.NumFields())
+		for i := range t.NumFields() {
+			v1, chngd, err := walkVar(t.Field(i))
+			if err != nil {
+				return nil, err
+			}
+			if chngd {
+				changed = true
+			}
+			fields[i] = v1
+		}
+		if !changed {
+			return t, nil
+		}
+		tags := make([]string, t.NumFields())
+		for i := range t.NumFields() {
+			tags[i] = t.Tag(i)
+		}
+		return types.NewStruct(fields, tags), nil
+	case *types.Pointer:
+		t1, changed, err := walk(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+		if !changed {
+			return t, nil
+		}
+		return types.NewPointer(t1), nil
+	case *types.Tuple:
+		t1, _, err := walkTuple(t)
+		return t1, err
+	case *types.Signature:
+		t1, _, err := walkSignature(t)
+		return t1, err
+	case *types.Union:
+		changed := false
+		terms := make([]*types.Term, t.Len())
+		for i := range t.Len() {
+			term := t.Term(i)
+			t1, chngd, err := walk(term.Type())
+			if err != nil {
+				return nil, err
+			}
+			if chngd {
+				changed = true
+			}
+			terms[i] = types.NewTerm(term.Tilde(), t1)
+		}
+		if !changed {
+			return t, nil
+		}
+		return types.NewUnion(terms), nil
+	case *types.Interface:
+		methods := make([]*types.Func, t.NumExplicitMethods())
+		methodsChanged := false
+		for i := range t.NumExplicitMethods() {
+			f := t.ExplicitMethod(i)
+			sig1, changed, err := walkSignature(f.Signature())
+			if err != nil {
+				return nil, err
+			}
+			if changed {
+				methodsChanged = true
+			}
+			methods[i] = types.NewFunc(f.Pos(), f.Pkg(), f.Name(), sig1)
+		}
+		embeddeds := make([]types.Type, t.NumEmbeddeds())
+		embeddedsChanged := false
+		for i := range t.NumEmbeddeds() {
+			e := t.EmbeddedType(i)
+			e1, changed, err := walk(e)
+			if err != nil {
+				return nil, err
+			}
+			if changed {
+				embeddedsChanged = true
+			}
+			embeddeds[i] = e1
+		}
+		if !methodsChanged && !embeddedsChanged {
+			return t, nil
+		}
+		return types.NewInterfaceType(methods, embeddeds), nil
+	case *types.Map:
+		k1, kChanged, err := walk(t.Key())
+		if err != nil {
+			return nil, err
+		}
+		v1, vChanged, err := walk(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+		if !kChanged && !vChanged {
+			return t, nil
+		}
+		return types.NewMap(k1, v1), nil
+	case *types.Chan:
+		t1, changed, err := walk(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+		if !changed {
+			return t, nil
+		}
+		return types.NewChan(t.Dir(), t1), nil
+	case *types.Named:
+		return t, nil
+	case *types.TypeParam:
+		return t, nil
+	case nil:
+		return nil, nil
+	default:
+		panic(fmt.Sprintf("WalkModify: unknown type %T", t))
+	}
+}

--- a/converter/walktypes/walktypes.go
+++ b/converter/walktypes/walktypes.go
@@ -16,7 +16,7 @@ import (
 // Walk calls fn on all immediate children of type t.
 // Returns early if fn returns an error.
 func Walk(t types.Type, fn func(types.Type) error) error {
-	walk := func(types.Type) error {
+	walk := func(t types.Type) error {
 		return fn(t)
 	}
 	walkVar := func(v *types.Var) error {

--- a/main.go
+++ b/main.go
@@ -526,7 +526,7 @@ Flags:
 		out.WriteString(goBuildLine)
 		out.WriteString("package main\n\n")
 		writeImports(&out, slices.Sorted(maps.Keys(imp.imports)))
-		out.WriteString(converter.InitCode)
+		out.WriteString(converter.PreludeCode)
 		out.WriteString("\n")
 		for _, k := range slices.Sorted(maps.Keys(imp.convs)) {
 			conv := imp.convs[k]

--- a/main.go
+++ b/main.go
@@ -96,11 +96,16 @@ type bindingFunc struct {
 }
 
 func newBindingFunc(f *types.Func) (bindingFunc, converter.ConverterSpec) {
+	if f.Name() == "ReadOptionalASN1Boolean" {
+		fmt.Println("fukkkk", f)
+		converter.TMP_SUPERDEBUG = true
+	}
 	typ := f.Type()
 	spec := converter.NewSpec(
 		typ,
 		converter.ToRye,
 	)
+	converter.TMP_SUPERDEBUG = false
 	return bindingFunc{
 		name:     f.Name(),
 		fn:       f,

--- a/ryegen_test.go
+++ b/ryegen_test.go
@@ -188,7 +188,7 @@ func checkFile(t *testing.T, dir, name string) {
 	{
 		var out bytes.Buffer
 		out.WriteString("package main\n\n")
-		out.WriteString(converter.InitCode)
+		out.WriteString(converter.PreludeCode)
 		out.WriteString("\n")
 		for _, k := range slices.Sorted(maps.Keys(convs)) {
 			conv := convs[k]


### PR DESCRIPTION
- Added an abstraction for interpreting bindspecs
- The converter now automatically tracks its dependency on any other converters. This lays the foundation for user-defined converters in the future.
- The converter implementation is generally a lot cleaner now. It has a ConverterSet, which contains all converters and makes the converter package significantly easier to use and its implementation more flexible.
- A few bugfixes